### PR TITLE
Add links to the other route and define the `/` route

### DIFF
--- a/gi-web.rb
+++ b/gi-web.rb
@@ -20,13 +20,15 @@ end
 get '/needs_qa' do
   label = 'Needs QA'
   prs = get_sorted_github_pr_list_by_label(label)
-  haml :index, :locals => {label: label, list: prs}
+  link ={label: 'Needs Code Review', endpoint: '/needs_cr'}
+  haml :index, :locals => {label: label, list: prs, link: link}
 end
 
 get '/needs_cr' do
   label = 'Needs Code Review'
   prs = get_sorted_github_pr_list_by_label(label)
-  haml :index, :locals => {label: label, list: prs}
+  link = {:label => 'Needs QA', :endpoint => '/needs_qa'}
+  haml :index, :locals => {label: label, list: prs, link: link }
 end
 
 def api_get(url)

--- a/gi-web.rb
+++ b/gi-web.rb
@@ -13,6 +13,10 @@ require 'haml'
 GITHUB_USERNAME = ENV['GITHUB_USERNAME']
 GITHUB_TOKEN = ENV['GITHUB_TOKEN']
 
+get '/' do
+  redirect '/needs_qa'
+end
+
 get '/needs_qa' do
   label = 'Needs QA'
   prs = get_sorted_github_pr_list_by_label(label)

--- a/views/index.haml
+++ b/views/index.haml
@@ -1,4 +1,7 @@
-%h2= label
+%h2
+  = label
+  |
+  %a{href: link[:endpoint]}= link[:label]
 %table{:border => '1', :cellpadding => '2'}
   %thead
     %tr


### PR DESCRIPTION
This PR does two things
1. makes it so that if you navigate the the `/` route, it will redirect to `/needs_qa`.
2. adds a link to the page that will take you to the other route option
